### PR TITLE
Feat/add camera info manager

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,10 @@ jobs:
             cd ..
             catkin build
       - run:
+          name: Lint
+          command: |
+            catkin bt --no-deps --make-args roslint
+      - run:
           name: Run Tests
           command: |
             cd ..
@@ -46,6 +50,10 @@ jobs:
             cd ..
             catkin build
       - run:
+          name: Lint
+          command: |
+            catkin bt --no-deps --make-args roslint
+      - run:
           name: Run Tests
           command: |
             cd ..
@@ -71,6 +79,10 @@ jobs:
           command: |
             cd ..
             catkin build
+      - run:
+          name: Lint
+          command: |
+            catkin bt --no-deps --make-args roslint
       - run:
           name: Run Tests
           command: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(catkin REQUIRED
   cv_bridge
   image_transport
   sensor_msgs
+  camera_info_manager
   roslint
 )
 
@@ -17,6 +18,8 @@ find_package(OpenCV REQUIRED)
 
 catkin_package(
   CATKIN_DEPENDS
+  camera_info_manager
+  image_transport
   cv_bridge
   nodelet
 )

--- a/example_calibrations/Boson640.yaml
+++ b/example_calibrations/Boson640.yaml
@@ -1,6 +1,6 @@
 image_width: 640
 image_height: 512
-camera_name: narrow_stereo
+camera_name: Boson640
 camera_matrix:
   rows: 3
   cols: 3

--- a/example_calibrations/Boson_640.yaml
+++ b/example_calibrations/Boson_640.yaml
@@ -1,0 +1,20 @@
+image_width: 640
+image_height: 512
+camera_name: narrow_stereo
+camera_matrix:
+  rows: 3
+  cols: 3
+  data: [767.942728, 0.000000, 317.244746, 0.000000, 767.068789, 231.644928, 0.000000, 0.000000, 1.000000]
+distortion_model: plumb_bob
+distortion_coefficients:
+  rows: 1
+  cols: 5
+  data: [-0.504042, 0.268940, 0.003454, -0.000748, 0.000000]
+rectification_matrix:
+  rows: 3
+  cols: 3
+  data: [1.000000, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, 1.000000]
+projection_matrix:
+  rows: 3
+  cols: 4
+  data: [694.958557, 0.000000, 316.182977, 0.000000, 0.000000, 720.968750, 229.582940, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000]

--- a/include/flir_boson_usb/BosonCamera.h
+++ b/include/flir_boson_usb/BosonCamera.h
@@ -98,7 +98,7 @@ class BosonCamera : public nodelet::Nodelet
             thermal_rgb_zoom, thermal_luma, thermal_rgb;
 
     // Default Program options
-    std::string dev_path;
+    std::string frame_id, dev_path, camera_info_url;
     Encoding video_mode;
     int32_t zoom_enable;
     SensorTypes sensor_type;

--- a/include/flir_boson_usb/BosonCamera.h
+++ b/include/flir_boson_usb/BosonCamera.h
@@ -98,10 +98,11 @@ class BosonCamera : public nodelet::Nodelet
             thermal_rgb_zoom, thermal_luma, thermal_rgb;
 
     // Default Program options
-    std::string frame_id, dev_path, camera_info_url;
+    std::string frame_id, dev_path, camera_info_url,
+      video_mode_str, sensor_type_str;
     float frame_rate;
     Encoding video_mode;
-    int32_t zoom_enable;
+    bool zoom_enable;
     SensorTypes sensor_type;
 };
 

--- a/include/flir_boson_usb/BosonCamera.h
+++ b/include/flir_boson_usb/BosonCamera.h
@@ -99,6 +99,7 @@ class BosonCamera : public nodelet::Nodelet
 
     // Default Program options
     std::string frame_id, dev_path, camera_info_url;
+    float frame_rate;
     Encoding video_mode;
     int32_t zoom_enable;
     SensorTypes sensor_type;

--- a/include/flir_boson_usb/BosonCamera.h
+++ b/include/flir_boson_usb/BosonCamera.h
@@ -42,6 +42,7 @@
 #include <nodelet/nodelet.h>
 #include <cv_bridge/cv_bridge.h>
 #include <image_transport/image_transport.h>
+#include <camera_info_manager/camera_info_manager.h>
 
 #include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/Image.h>
@@ -64,7 +65,7 @@ enum SensorTypes
 class BosonCamera : public nodelet::Nodelet
 {
   public:
-    BosonCamera() {}
+    BosonCamera();
     ~BosonCamera();
 
   private:
@@ -77,7 +78,10 @@ class BosonCamera : public nodelet::Nodelet
     bool closeCamera();
     void captureAndPublish(const ros::TimerEvent& evt);
 
-    image_transport::Publisher image_pub;
+    ros::NodeHandle nh, pnh;
+    boost::shared_ptr<camera_info_manager::CameraInfoManager> camera_info;
+    boost::shared_ptr<image_transport::ImageTransport> it;
+    image_transport::CameraPublisher image_pub;
     cv_bridge::CvImage cv_img;
     sensor_msgs::ImagePtr pub_image;
     ros::Timer capture_timer;

--- a/include/flir_boson_usb/BosonCamera.h
+++ b/include/flir_boson_usb/BosonCamera.h
@@ -79,8 +79,8 @@ class BosonCamera : public nodelet::Nodelet
     void captureAndPublish(const ros::TimerEvent& evt);
 
     ros::NodeHandle nh, pnh;
-    boost::shared_ptr<camera_info_manager::CameraInfoManager> camera_info;
-    boost::shared_ptr<image_transport::ImageTransport> it;
+    std::shared_ptr<camera_info_manager::CameraInfoManager> camera_info;
+    std::shared_ptr<image_transport::ImageTransport> it;
     image_transport::CameraPublisher image_pub;
     cv_bridge::CvImage cv_img;
     sensor_msgs::ImagePtr pub_image;

--- a/launch/flir_boson.launch
+++ b/launch/flir_boson.launch
@@ -22,12 +22,12 @@
   <arg name="camera_info_url" default="package://flir_boson_usb/example_calibrations/Boson640.yaml"/>
 
   <node pkg="flir_boson_usb" type="flir_boson_usb_node" name="flir_boson_usb_node" ns="$(arg namespace)">
-    <param name="frame_id" value="$(arg frame_id)"/>
-    <param name="dev" value="$(arg dev)"/>
-    <param name="frame_rate" value="$(arg frame_rate)"/>
-    <param name="video_mode" value="$(arg video_mode)"/>
-    <param name="zoom_enable" value="$(arg zoom_enable)"/>
-    <param name="sensor_type" value="$(arg sensor_type)"/>
-    <param name="camera_info_url" value="$(arg camera_info_url)"/>
+    <param name="frame_id" type="str" value="$(arg frame_id)"/>
+    <param name="dev" type="str" value="$(arg dev)"/>
+    <param name="frame_rate" type="double" value="$(arg frame_rate)"/>
+    <param name="video_mode" type="str" value="$(arg video_mode)"/>
+    <param name="zoom_enable" type="bool" value="$(arg zoom_enable)"/>
+    <param name="sensor_type" type="str" value="$(arg sensor_type)"/>
+    <param name="camera_info_url" type="str" value="$(arg camera_info_url)"/>
   </node>
 </launch>

--- a/launch/flir_boson.launch
+++ b/launch/flir_boson.launch
@@ -6,6 +6,9 @@
   <!-- the linux file descriptor location for the camera -->
   <arg name="dev" default="/dev/video0"/>
 
+  <!-- valid values are 30.0 or 60.0 for Bosons -->
+  <arg name="frame_rate" default="30.0"/>
+
   <!-- valid values are RAW16 or YUV -->
   <arg name="video_mode" default="YUV"/>
 
@@ -21,6 +24,7 @@
   <node pkg="flir_boson_usb" type="flir_boson_usb_node" name="flir_boson_usb_node" ns="$(arg namespace)">
     <param name="frame_id" value="$(arg frame_id)"/>
     <param name="dev" value="$(arg dev)"/>
+    <param name="frame_rate" value="$(arg frame_rate)"/>
     <param name="video_mode" value="$(arg video_mode)"/>
     <param name="zoom_enable" value="$(arg zoom_enable)"/>
     <param name="sensor_type" value="$(arg sensor_type)"/>

--- a/launch/flir_boson.launch
+++ b/launch/flir_boson.launch
@@ -7,7 +7,7 @@
   <arg name="dev" default="/dev/video0"/>
 
   <!-- valid values are 30.0 or 60.0 for Bosons -->
-  <arg name="frame_rate" default="30.0"/>
+  <arg name="frame_rate" default="60.0"/>
 
   <!-- valid values are RAW16 or YUV -->
   <arg name="video_mode" default="YUV"/>

--- a/launch/flir_boson.launch
+++ b/launch/flir_boson.launch
@@ -12,10 +12,13 @@
   <!-- valid values are Boson_320 or Boson_640 -->
   <arg name="sensor_type" default="Boson_640"/>
 
+  <arg name="camera_info_url" default="package://flir_boson_usb/example_calibrations/Boson_640.yaml" />
+
   <node pkg="flir_boson_usb" type="flir_boson_usb_node" name="flir_boson_usb_node">
     <param name="dev" value="$(arg dev)"/>
     <param name="video_mode" value="$(arg video_mode)"/>
     <param name="zoom_enable" value="$(arg zoom_enable)"/>
     <param name="sensor_type" value="$(arg sensor_type)"/>
+    <param name="camera_info_url" value="$(arg camera_info_url)"/>
   </node>
 </launch>

--- a/launch/flir_boson.launch
+++ b/launch/flir_boson.launch
@@ -2,9 +2,6 @@
 <launch>
   <arg name="namespace" default="flir_boson"/>
 
-  <!-- wether or not we want to rectfy the image with image_proc -->
-  <arg name="rectify_image" default="false"/>
-
   <!-- the linux file descriptor location for the camera -->
   <arg name="dev" default="/dev/video0"/>
 
@@ -20,15 +17,11 @@
   <!-- location of the camera calibration file -->
   <arg name="camera_info_url" default="package://flir_boson_usb/example_calibrations/Boson640.yaml"/>
 
-  <group ns="$(arg namespace)">
-    <node pkg="flir_boson_usb" type="flir_boson_usb_node" name="flir_boson_usb_node">
-      <param name="dev" value="$(arg dev)"/>
-      <param name="video_mode" value="$(arg video_mode)"/>
-      <param name="zoom_enable" value="$(arg zoom_enable)"/>
-      <param name="sensor_type" value="$(arg sensor_type)"/>
-      <param name="camera_info_url" value="$(arg camera_info_url)"/>
-    </node>
-
-    <node pkg="image_proc" type="image_proc" name="image_proc" if="$(arg rectify_image)"/>
-  </group>
+  <node pkg="flir_boson_usb" type="flir_boson_usb_node" name="flir_boson_usb_node" ns="$(arg namespace)">
+    <param name="dev" value="$(arg dev)"/>
+    <param name="video_mode" value="$(arg video_mode)"/>
+    <param name="zoom_enable" value="$(arg zoom_enable)"/>
+    <param name="sensor_type" value="$(arg sensor_type)"/>
+    <param name="camera_info_url" value="$(arg camera_info_url)"/>
+  </node>
 </launch>

--- a/launch/flir_boson.launch
+++ b/launch/flir_boson.launch
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="namespace" default="flir_boson"/>
+  <arg name="frame_id" default="boson_camera"/>
 
   <!-- the linux file descriptor location for the camera -->
   <arg name="dev" default="/dev/video0"/>
@@ -18,6 +19,7 @@
   <arg name="camera_info_url" default="package://flir_boson_usb/example_calibrations/Boson640.yaml"/>
 
   <node pkg="flir_boson_usb" type="flir_boson_usb_node" name="flir_boson_usb_node" ns="$(arg namespace)">
+    <param name="frame_id" value="$(arg frame_id)"/>
     <param name="dev" value="$(arg dev)"/>
     <param name="video_mode" value="$(arg video_mode)"/>
     <param name="zoom_enable" value="$(arg zoom_enable)"/>

--- a/launch/flir_boson.launch
+++ b/launch/flir_boson.launch
@@ -1,6 +1,11 @@
 <?xml version="1.0"?>
 <launch>
-  <!-- declare arguments with default values -->
+  <arg name="namespace" default="flir_boson"/>
+
+  <!-- wether or not we want to rectfy the image with image_proc -->
+  <arg name="rectify_image" default="false"/>
+
+  <!-- the linux file descriptor location for the camera -->
   <arg name="dev" default="/dev/video0"/>
 
   <!-- valid values are RAW16 or YUV -->
@@ -12,13 +17,18 @@
   <!-- valid values are Boson_320 or Boson_640 -->
   <arg name="sensor_type" default="Boson_640"/>
 
-  <arg name="camera_info_url" default="package://flir_boson_usb/example_calibrations/Boson_640.yaml" />
+  <!-- location of the camera calibration file -->
+  <arg name="camera_info_url" default="package://flir_boson_usb/example_calibrations/Boson640.yaml"/>
 
-  <node pkg="flir_boson_usb" type="flir_boson_usb_node" name="flir_boson_usb_node">
-    <param name="dev" value="$(arg dev)"/>
-    <param name="video_mode" value="$(arg video_mode)"/>
-    <param name="zoom_enable" value="$(arg zoom_enable)"/>
-    <param name="sensor_type" value="$(arg sensor_type)"/>
-    <param name="camera_info_url" value="$(arg camera_info_url)"/>
-  </node>
+  <group ns="$(arg namespace)">
+    <node pkg="flir_boson_usb" type="flir_boson_usb_node" name="flir_boson_usb_node">
+      <param name="dev" value="$(arg dev)"/>
+      <param name="video_mode" value="$(arg video_mode)"/>
+      <param name="zoom_enable" value="$(arg zoom_enable)"/>
+      <param name="sensor_type" value="$(arg sensor_type)"/>
+      <param name="camera_info_url" value="$(arg camera_info_url)"/>
+    </node>
+
+    <node pkg="image_proc" type="image_proc" name="image_proc" if="$(arg rectify_image)"/>
+  </group>
 </launch>

--- a/launch/flir_boson_rectified.launch
+++ b/launch/flir_boson_rectified.launch
@@ -7,6 +7,9 @@
   <!-- the linux file descriptor location for the camera -->
   <arg name="dev" default="/dev/video0"/>
 
+  <!-- valid values are 30.0 or 60.0 for Bosons -->
+  <arg name="frame_rate" default="30.0"/>
+
   <!-- valid values are RAW16 or YUV -->
   <arg name="video_mode" default="YUV"/>
 
@@ -26,6 +29,7 @@
     <node pkg="nodelet" type="nodelet" name="$(arg manager)_driver" args="load flir_boson_usb/BosonCamera $(arg manager)">
       <param name="frame_id" value="$(arg frame_id)"/>
       <param name="dev" value="$(arg dev)"/>
+      <param name="frame_rate" value="$(arg frame_rate)"/>
       <param name="video_mode" value="$(arg video_mode)"/>
       <param name="zoom_enable" value="$(arg zoom_enable)"/>
       <param name="sensor_type" value="$(arg sensor_type)"/>

--- a/launch/flir_boson_rectified.launch
+++ b/launch/flir_boson_rectified.launch
@@ -27,13 +27,13 @@
     <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" />
 
     <node pkg="nodelet" type="nodelet" name="$(arg manager)_driver" args="load flir_boson_usb/BosonCamera $(arg manager)">
-      <param name="frame_id" value="$(arg frame_id)"/>
-      <param name="dev" value="$(arg dev)"/>
-      <param name="frame_rate" value="$(arg frame_rate)"/>
-      <param name="video_mode" value="$(arg video_mode)"/>
-      <param name="zoom_enable" value="$(arg zoom_enable)"/>
-      <param name="sensor_type" value="$(arg sensor_type)"/>
-      <param name="camera_info_url" value="$(arg camera_info_url)"/>
+      <param name="frame_id" type="str" value="$(arg frame_id)"/>
+      <param name="dev" type="str" value="$(arg dev)"/>
+      <param name="frame_rate" type="double" value="$(arg frame_rate)"/>
+      <param name="video_mode" type="str" value="$(arg video_mode)"/>
+      <param name="zoom_enable" type="bool" value="$(arg zoom_enable)"/>
+      <param name="sensor_type" type="str" value="$(arg sensor_type)"/>
+      <param name="camera_info_url" type="str" value="$(arg camera_info_url)"/>
     </node>
 
     <node pkg="nodelet" type="nodelet" name="$(arg manager)_image_proc" args="load image_proc/rectify $(arg manager)">

--- a/launch/flir_boson_rectified.launch
+++ b/launch/flir_boson_rectified.launch
@@ -1,9 +1,7 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="namespace" default="flir_boson"/>
-
   <arg name="frame_id" default="boson_camera" />
-
   <arg name="manager" default="$(arg frame_id)_nodelet_manager" />
 
   <!-- the linux file descriptor location for the camera -->
@@ -26,6 +24,7 @@
     <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" />
 
     <node pkg="nodelet" type="nodelet" name="$(arg manager)_driver" args="load flir_boson_usb/BosonCamera $(arg manager)">
+      <param name="frame_id" value="$(arg frame_id)"/>
       <param name="dev" value="$(arg dev)"/>
       <param name="video_mode" value="$(arg video_mode)"/>
       <param name="zoom_enable" value="$(arg zoom_enable)"/>

--- a/launch/flir_boson_rectified.launch
+++ b/launch/flir_boson_rectified.launch
@@ -8,7 +8,7 @@
   <arg name="dev" default="/dev/video0"/>
 
   <!-- valid values are 30.0 or 60.0 for Bosons -->
-  <arg name="frame_rate" default="30.0"/>
+  <arg name="frame_rate" default="60.0"/>
 
   <!-- valid values are RAW16 or YUV -->
   <arg name="video_mode" default="YUV"/>

--- a/launch/flir_boson_rectified.launch
+++ b/launch/flir_boson_rectified.launch
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="namespace" default="flir_boson"/>
+
+  <arg name="frame_id" default="boson_camera" />
+
+  <arg name="manager" default="$(arg frame_id)_nodelet_manager" />
+
+  <!-- the linux file descriptor location for the camera -->
+  <arg name="dev" default="/dev/video0"/>
+
+  <!-- valid values are RAW16 or YUV -->
+  <arg name="video_mode" default="YUV"/>
+
+  <!-- valid values are TRUE or FALSE -->
+  <arg name="zoom_enable" default="FALSE"/>
+
+  <!-- valid values are Boson_320 or Boson_640 -->
+  <arg name="sensor_type" default="Boson_640"/>
+
+  <!-- location of the camera calibration file -->
+  <arg name="camera_info_url" default="package://flir_boson_usb/example_calibrations/Boson640.yaml"/>
+
+  <group ns="$(arg namespace)">
+    <!-- start nodelet manager -->
+    <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" />
+
+    <node pkg="nodelet" type="nodelet" name="$(arg manager)_driver" args="load flir_boson_usb/BosonCamera $(arg manager)">
+      <param name="dev" value="$(arg dev)"/>
+      <param name="video_mode" value="$(arg video_mode)"/>
+      <param name="zoom_enable" value="$(arg zoom_enable)"/>
+      <param name="sensor_type" value="$(arg sensor_type)"/>
+      <param name="camera_info_url" value="$(arg camera_info_url)"/>
+    </node>
+
+    <node pkg="nodelet" type="nodelet" name="$(arg manager)_image_proc" args="load image_proc/rectify $(arg manager)">
+      <remap from="image_mono" to="image_raw"/>
+    </node>
+  </group>
+</launch>

--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
   <depend>roscpp</depend>
   <depend>nodelet</depend>
   <depend>cv_bridge</depend>
+  <depend>camera_info_manager</depend>
   <depend>image_transport</depend>
   <depend>sensor_msgs</depend>
 

--- a/src/nodelets/BosonCamera.cpp
+++ b/src/nodelets/BosonCamera.cpp
@@ -40,9 +40,9 @@ void BosonCamera::onInit()
 {
   nh = getNodeHandle();
   pnh = getPrivateNodeHandle();
-  camera_info = boost::shared_ptr<camera_info_manager::CameraInfoManager>(
+  camera_info = std::shared_ptr<camera_info_manager::CameraInfoManager>(
       new camera_info_manager::CameraInfoManager(nh));
-  it = boost::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(nh));
+  it = std::shared_ptr<image_transport::ImageTransport>(new image_transport::ImageTransport(nh));
   image_pub = it->advertiseCamera("image_raw", 1);
 
   bool exit = false;

--- a/src/nodelets/BosonCamera.cpp
+++ b/src/nodelets/BosonCamera.cpp
@@ -114,7 +114,8 @@ void BosonCamera::onInit()
   }
   else
   {
-    capture_timer = nh.createTimer(ros::Duration(1.0 / frame_rate), boost::bind(&BosonCamera::captureAndPublish, this, _1));
+    capture_timer = nh.createTimer(ros::Duration(1.0 / frame_rate),
+        boost::bind(&BosonCamera::captureAndPublish, this, _1));
   }
 }
 
@@ -226,7 +227,7 @@ bool BosonCamera::openCamera()
   // request desired FORMAT
   if (ioctl(fd, VIDIOC_S_FMT, &format) < 0)
   {
-    ROS_ERROR("flir_boson_usb - VIDIOC_S_FMT error.");
+    ROS_ERROR("flir_boson_usb - VIDIOC_S_FMT error. The camera does not support the requested video format.");
     return false;
   }
 
@@ -242,7 +243,7 @@ bool BosonCamera::openCamera()
 
   if (ioctl(fd, VIDIOC_REQBUFS, &bufrequest) < 0)
   {
-    ROS_ERROR("flir_boson_usb - VIDIOC_REQBUFS error.");
+    ROS_ERROR("flir_boson_usb - VIDIOC_REQBUFS error. The camera failed to allocate a buffer.");
     return false;
   }
 
@@ -259,7 +260,7 @@ bool BosonCamera::openCamera()
 
   if (ioctl(fd, VIDIOC_QUERYBUF, &bufferinfo) < 0)
   {
-    ROS_ERROR("flir_boson_usb - VIDIOC_QUERYBUF error.");
+    ROS_ERROR("flir_boson_usb - VIDIOC_QUERYBUF error. Failed to retreive buffer information.");
     return false;
   }
 
@@ -269,7 +270,7 @@ bool BosonCamera::openCamera()
 
   if (buffer_start == MAP_FAILED)
   {
-    ROS_ERROR("flir_boson_usb - mmap error.");
+    ROS_ERROR("flir_boson_usb - mmap error. Failed to create a memory map for buffer.");
     return false;
   }
 
@@ -280,7 +281,7 @@ bool BosonCamera::openCamera()
   int type = bufferinfo.type;
   if (ioctl(fd, VIDIOC_STREAMON, &type) < 0)
   {
-    ROS_ERROR("flir_boson_usb - VIDIOC_STREAMON error.");
+    ROS_ERROR("flir_boson_usb - VIDIOC_STREAMON error. Failed to activate streaming on the camera.");
     return false;
   }
 
@@ -316,7 +317,7 @@ bool BosonCamera::closeCamera()
   int type = bufferinfo.type;
   if (ioctl(fd, VIDIOC_STREAMOFF, &type) < 0 )
   {
-    ROS_ERROR("flir_boson_usb - VIDIOC_STREAMOFF error.");
+    ROS_ERROR("flir_boson_usb - VIDIOC_STREAMOFF error. Failed to disable streaming on the camera.");
     return false;
   };
 
@@ -337,14 +338,14 @@ void BosonCamera::captureAndPublish(const ros::TimerEvent& evt)
   // Put the buffer in the incoming queue.
   if (ioctl(fd, VIDIOC_QBUF, &bufferinfo) < 0)
   {
-    ROS_ERROR("flir_boson_usb - VIDIOC_QBUF error.");
+    ROS_ERROR("flir_boson_usb - VIDIOC_QBUF error. Failed to queue the image buffer.");
     return;
   }
 
   // The buffer's waiting in the outgoing queue.
   if (ioctl(fd, VIDIOC_DQBUF, &bufferinfo) < 0)
   {
-    ROS_ERROR("flir_boson_usb - VIDIOC_DQBUF error.");
+    ROS_ERROR("flir_boson_usb - VIDIOC_DQBUF error. Failed to dequeue the image buffer.");
     return;
   }
 

--- a/src/nodelets/BosonCamera.cpp
+++ b/src/nodelets/BosonCamera.cpp
@@ -49,7 +49,7 @@ void BosonCamera::onInit()
 
   pnh.param<std::string>("frame_id", frame_id, "boson_camera");
   pnh.param<std::string>("dev", dev_path, "/dev/video0");
-  pnh.param<float>("frame_rate", frame_rate, 30.0);
+  pnh.param<float>("frame_rate", frame_rate, 60.0);
   pnh.param<std::string>("video_mode", video_mode_str, "RAW16");
   pnh.param<bool>("zoon_enable", zoom_enable, false);
   pnh.param<std::string>("sensor_type", sensor_type_str, "Boson_640");


### PR DESCRIPTION
This branch adds a Camera Info Manager (allows the loading of camera calibrations), moves further away from boost, adds the ability to provide a frame rate and frame_id, and adds more detailed error messages.