### PR TITLE
Fix issues detected by catkin_lint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ catkin_package(
   image_transport
   cv_bridge
   nodelet
+  sensor_msgs
 )
 
 include_directories(
@@ -69,6 +70,10 @@ install(TARGETS ${PROJECT_NAME}_node BosonCamera
 
 install(DIRECTORY
   launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+install(FILES nodelet_plugins.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 


### PR DESCRIPTION
This PR provides fixes to two minor issues picked up by catkin_lint:
* flir_boson_usb: CMakeLists.txt: error: nodelet plugin file 'nodelet_plugins.xml' is not installed to ${CATKIN_PACKAGE_SHARE_DESTINATION}
  * Your package can be used from the devel space but cannot be installed properly, because a plugin declaration file which is listed in your package.xml is not installed to the correct location.
You can ignore this problem with --ignore uninstalled_plugin

* flir_boson_usb: CMakeLists.txt(19): warning: package 'sensor_msgs' should be listed in catkin_package()
